### PR TITLE
ADD: Paralellism and a few bugfixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ install:
 script:
     - eval xvfb-run pytest
     - source continuous_integration/build_docs.sh
-    - flake8 --max-line-length=115 --ignore=F401,E402,W504,W605
+    - flake8 --max-line-length=115 --ignore=F401,E402,W504,W605,E731

--- a/emc2/core/model.py
+++ b/emc2/core/model.py
@@ -481,10 +481,10 @@ class TestAllStratiform(Model):
         N = xr.DataArray(N.magnitude[np.newaxis, :], dims=('time', 'height'))
         N.attrs["long_name"] = "Cloud particle number concentration"
         N.attrs["units"] = '%s' % N_units
-        qcl = xr.DataArray(qcl.magnitude[np.newaxis, :], dims=('time', 'height'))
+        qcl = xr.DataArray(qcl[np.newaxis, :], dims=('time', 'height'))
         qcl.attrs["units"] = "g kg-1"
         qcl.attrs["long_name"] = "Cloud liquid water mixing ratio"
-        qci = xr.DataArray(qci.magnitude[np.newaxis, :], dims=('time', 'height'))
+        qci = xr.DataArray(qci[np.newaxis, :], dims=('time', 'height'))
         qci.attrs["units"] = "g kg-1"
         qci.attrs["long_name"] = "Cloud ice water mixing ratio"
 

--- a/emc2/core/model.py
+++ b/emc2/core/model.py
@@ -481,10 +481,10 @@ class TestAllStratiform(Model):
         N = xr.DataArray(N.magnitude[np.newaxis, :], dims=('time', 'height'))
         N.attrs["long_name"] = "Cloud particle number concentration"
         N.attrs["units"] = '%s' % N_units
-        qcl = xr.DataArray(qcl[np.newaxis, :], dims=('time', 'height'))
+        qcl = xr.DataArray(qcl.magnitude[np.newaxis, :], dims=('time', 'height'))
         qcl.attrs["units"] = "g kg-1"
         qcl.attrs["long_name"] = "Cloud liquid water mixing ratio"
-        qci = xr.DataArray(qci[np.newaxis, :], dims=('time', 'height'))
+        qci = xr.DataArray(qci.magnitude[np.newaxis, :], dims=('time', 'height'))
         qci.attrs["units"] = "g kg-1"
         qci.attrs["long_name"] = "Cloud ice water mixing ratio"
 

--- a/emc2/simulator/lidar_moments.py
+++ b/emc2/simulator/lidar_moments.py
@@ -1,5 +1,6 @@
 import xarray as xr
 import numpy as np
+import dask.bag as db
 
 from ..core import Instrument, Model
 from .attenuation import calc_theory_beta_m
@@ -7,15 +8,13 @@ from .psd import calc_mu_lambda
 from ..core.instrument import ureg, quantity
 
 
-def calc_LDR(instrument, model, ext_OD, OD_from_sfc=True, LDR_per_hyd=None, is_conv=True):
+def calc_LDR(model, ext_OD=10., OD_from_sfc=True, LDR_per_hyd=None):
     """
     Calculates the lidar extinction mask and linear depolarization ratio for
     the given model and lidar.
 
     Parameters
     ----------
-    instrument: Instrument
-        The instrument to simulate. The instrument must be a lidar.
     model: Model
         The model to generate the parameters for.
     ext_OD: float
@@ -27,9 +26,7 @@ def calc_LDR(instrument, model, ext_OD, OD_from_sfc=True, LDR_per_hyd=None, is_c
         If a dict, the amount of LDR per hydrometeor class must be specified in
         a dictionary whose keywords are the model's hydrometeor classes. If None,
         the default settings from the model will be used.
-    is_conv: bool
-        If true, calculate LDR for convective clouds. If False, LDR will be
-        calculated for stratiform clouds.
+.
 
     Returns
     -------
@@ -40,24 +37,20 @@ def calc_LDR(instrument, model, ext_OD, OD_from_sfc=True, LDR_per_hyd=None, is_c
     if LDR_per_hyd is None:
         LDR_per_hyd = model.LDR_per_hyd
 
-    if is_conv:
-        cloud_class = "conv"
-    else:
-        cloud_class = "strat"
+    for cloud_class in ["conv", "strat"]:
+        numerator = 0.
+        denominator = 0.
 
-    numerator = 0.
-    denominator = 0.
+        for hyd_type in model.hydrometeor_classes:
+            beta_p_key = "sub_col_beta_p_%s_%s" % (hyd_type, cloud_class)
+            numerator += model.ds[beta_p_key] * model.LDR_per_hyd[hyd_type].magnitude
+            denominator += model.ds[beta_p_key]
 
-    for hyd_type in model.hydrometeor_classes:
-        beta_p_key = "sub_col_beta_p_%s_%s" % (hyd_type, cloud_class)
-        numerator += model.ds[beta_p_key] * model.LDR_per_hyd[hyd_type]
-        denominator += model.ds[beta_p_key]
+        model.ds["LDR_%s" % cloud_class] = numerator / denominator
+        model.ds["LDR_%s" % cloud_class].attrs["long_name"] = "Linear depolarization ratio in %s" % cloud_class
+        model.ds["LDR_%s" % cloud_class].attrs["units"] = "1"
 
-    model.ds["LDR"] = numerator / denominator
-    model.ds["LDR"] = model.ds["LDR"].where(model.ds["LDR"] != 0.)
-    model.ds["LDR"].attrs["long_name"] = "Linear depolarization ratio"
-
-    OD_cum_p_tot = model.ds["sub_col_OD_tot_%s" % cloud_class].values
+    OD_cum_p_tot = model.ds["sub_col_OD_tot_strat"].values + model.ds["sub_col_OD_tot_conv"].values
     OD_cum_p_tot = np.where(OD_cum_p_tot > ext_OD, 2, 0.)
     my_diff = np.diff(OD_cum_p_tot, axis=2, prepend=0)
     ext_tmp = np.where(my_diff > 1., 1, 0)
@@ -66,7 +59,7 @@ def calc_LDR(instrument, model, ext_OD, OD_from_sfc=True, LDR_per_hyd=None, is_c
     if not OD_from_sfc:
         ext_mask = np.flip(ext_mask, axis=2)
 
-    model.ds["ext_mask"] = xr.DataArray(ext_mask, dims=model.ds["LDR"].dims)
+    model.ds["ext_mask"] = xr.DataArray(ext_mask, dims=model.ds["LDR_conv"].dims)
     model.ds["ext_mask"].attrs["long_name"] = "Extinction mask"
     model.ds["ext_mask"].attrs["units"] = ("2 = Signal extinct, 1 = layer where signal becomes " +
                                            "extinct, 0 = signal not extinct")
@@ -74,8 +67,8 @@ def calc_LDR(instrument, model, ext_OD, OD_from_sfc=True, LDR_per_hyd=None, is_c
     return model
 
 
-def calc_lidar_moments(instrument, model, is_conv, ext_OD=10,
-                       OD_from_sfc=True, **kwargs):
+def calc_lidar_moments(instrument, model, is_conv,
+                       OD_from_sfc=True, parallel=True, **kwargs):
     """
     Calculates the lidar backscatter, extinction, and optical depth
     in a given column for the given lidar.
@@ -88,13 +81,12 @@ def calc_lidar_moments(instrument, model, is_conv, ext_OD=10,
         The model to generate the parameters for.
     is_conv: bool
         True if the cell is convective
-    ext_OD: float
-        The optical depth at which the lidar signal is fully extinct.
     z_field: str
         The name of the altitude field to use.
     OD_from_sfc: bool
         If True, then calculate optical depth from the surface.
-
+    parallel: bool
+        If True, use parallelism in calculating lidar parameters.
     Additonal keyword arguments are passed into
     :py:func:`emc2.simulator.lidar_moments.calc_LDR`.
 
@@ -156,7 +148,7 @@ def calc_lidar_moments(instrument, model, is_conv, ext_OD=10,
                     WC / (a**(1 / b)), dims=model.ds["conv_q_subcolumns_cl"].dims)
 
             model.ds["sub_col_beta_p_%s_conv" % hyd_type] = model.ds["sub_col_alpha_p_%s_conv" % hyd_type] / \
-                model.lidar_ratio[hyd_type]
+                model.lidar_ratio[hyd_type].magnitude
             model.ds["sub_col_alpha_p_%s_conv" % hyd_type] = \
                 model.ds["sub_col_alpha_p_%s_conv" % hyd_type].fillna(0)
             model.ds["sub_col_beta_p_%s_conv" % hyd_type] = \
@@ -184,13 +176,6 @@ def calc_lidar_moments(instrument, model, is_conv, ext_OD=10,
                 "Optical depth from %s in convective clouds" % hyd_names_dict[hyd_type]
             model.ds["sub_col_OD_%s_conv" % hyd_type].attrs["units"] = "1"
 
-        model = calc_LDR(instrument, model, ext_OD, OD_from_sfc, **kwargs)
-        model.ds["sub_col_beta_p_tot_conv"] = model.ds["sub_col_beta_p_tot_conv"].where(
-            model.ds["sub_col_beta_p_tot_conv"] != 0)
-        model.ds["sub_col_alpha_p_tot_conv"] = model.ds["sub_col_alpha_p_tot_conv"].where(
-            model.ds["sub_col_alpha_p_tot_conv"] != 0)
-        model.ds["sub_col_OD_tot_conv"] = model.ds["sub_col_OD_tot_conv"].where(
-            model.ds["sub_col_OD_tot_conv"] != 0)
         model.ds["sub_col_beta_p_tot_conv"].attrs["long_name"] = \
             "Backscatter coefficient from all hydrometeors in convective clouds"
         model.ds["sub_col_beta_p_tot_conv"].attrs["units"] = "m^-1"
@@ -218,7 +203,6 @@ def calc_lidar_moments(instrument, model, is_conv, ext_OD=10,
         Dims = column_ds["strat_q_subcolumns_cl"].values.shape
         for hyd_type in ["pi", "pl", "ci", "cl"]:
             print("Generating stratiform radar moments for hydrometeor class %s" % hyd_type)
-            num_diam = len(instrument.mie_table[hyd_type]["p_diam"].values)
             if hyd_type == "pi":
                 model.ds["sub_col_beta_p_tot_strat"] = xr.DataArray(
                     np.zeros(Dims), dims=model.ds.strat_q_subcolumns_cl.dims)
@@ -234,39 +218,42 @@ def calc_lidar_moments(instrument, model, is_conv, ext_OD=10,
                 instrument.mie_table[hyd_type]["p_diam"].values[0]
             fits_ds = calc_mu_lambda(model, hyd_type, subcolumns=True, **kwargs).ds
             total_hydrometeor = column_ds[frac_names[hyd_type]] * column_ds[n_names[hyd_type]]
+            N_0 = fits_ds["N_0"].values
+            mu = fits_ds["mu"].values
+            num_subcolumns = model.num_subcolumns
+            p_diam = instrument.mie_table[hyd_type]["p_diam"].values
+            lambdas = fits_ds["lambda"].values
+            beta_p = instrument.mie_table[hyd_type]["beta_p"].values
+            alpha_p = instrument.mie_table[hyd_type]["alpha_p"].values
+            _calc_lidar = lambda x: _calc_strat_lidar_properties(
+                x, N_0, lambdas, mu, p_diam, total_hydrometeor, hyd_type, num_subcolumns, dD,
+                beta_p, alpha_p)
+            if parallel:
+                tt_bag = db.from_sequence(np.arange(0, Dims[1], 1))
+                lists = tt_bag.map(_calc_lidar).compute()
+            else:
+                lists = [x for x in map(_calc_lidar, np.arange(0, Dims[1], 1))]
+            beta_p_strat = np.stack([x[0] for x in lists], axis=1)
+            alpha_p_strat = np.stack([x[1] for x in lists], axis=1)
 
-            for tt in range(Dims[1]):
-                if tt % 50 == 0:
-                    print('Stratiform moment for class %s progress: %d/%d' % (hyd_type, tt, Dims[1]))
-                for k in range(Dims[2]):
-                    if total_hydrometeor.values[tt, k] == 0:
-                        continue
+            model.ds["sub_col_beta_p_%s_strat" % hyd_type][:, :, :] = beta_p_strat
+            model.ds["sub_col_alpha_p_%s_strat" % hyd_type][:, :, :] = alpha_p_strat
+            model.ds["sub_col_beta_p_%s_strat" % hyd_type] = \
+                model.ds["sub_col_beta_p_%s_strat" % hyd_type].fillna(0)
+            model.ds["sub_col_alpha_p_%s_strat" % hyd_type] = \
+                model.ds["sub_col_alpha_p_%s_strat" % hyd_type].fillna(0)
 
-                    N_0_tmp = np.tile(fits_ds["N_0"][:, tt, k].values, (num_diam, 1)).T
-                    lambda_tmp = np.tile(fits_ds["lambda"][:, tt, k].values, (num_diam, 1)).T
-                    p_diam_tiled = np.tile(
-                        instrument.mie_table[hyd_type]["p_diam"], (model.num_subcolumns, 1))
-                    mu_temp = np.tile(fits_ds["mu"].values[:, tt, k], (num_diam, 1)).T
-                    N_D = N_0_tmp * p_diam_tiled ** mu_temp * np.exp(-lambda_tmp * p_diam_tiled)
-                    Calc_tmp = np.tile(instrument.mie_table[hyd_type]["beta_p"],
-                                       (model.num_subcolumns, 1)) * N_D
-                    model.ds["sub_col_beta_p_%s_strat" % hyd_type][:, tt, k] = (
-                        Calc_tmp[:, :].sum(axis=1) / 2 + Calc_tmp[:, 1:-1].sum(axis=1)) * dD
-                    Calc_tmp = np.tile(instrument.mie_table[hyd_type]["alpha_p"],
-                                       (model.num_subcolumns, 1)) * N_D
-                    model.ds["sub_col_alpha_p_%s_strat" % hyd_type][:, tt, k] = (
-                        Calc_tmp[:, :].sum(axis=1) / 2 + Calc_tmp[:, 1:-1].sum(axis=1)) * dD
+            if OD_from_sfc:
+                dz = np.diff(z_values, axis=1, prepend=0)
+                dz = np.tile(dz, (model.num_subcolumns, 1, 1))
+                model.ds["sub_col_OD_%s_strat" % hyd_type] = np.cumsum(
+                    dz * model.ds["sub_col_alpha_p_%s_strat" % hyd_type], axis=2)
+            else:
+                dz = np.diff(z_values, axis=1, prepend=0)
+                dz = np.tile(dz, (model.num_subcolumns, 1, 1))
+                model.ds["sub_col_OD_%s_conv" % hyd_type] = np.flip(np.cumsum(
+                    dz * model.ds["sub_col_alpha_p_%s_strat" % hyd_type], axis=2), axis=2)
 
-        if OD_from_sfc:
-            dz = np.diff(z_values, axis=1, prepend=0)
-            dz = np.tile(dz, (model.num_subcolumns, 1, 1))
-            model.ds["sub_col_OD_%s_strat" % hyd_type] = np.cumsum(
-                dz * model.ds["sub_col_alpha_p_%s_strat" % hyd_type], axis=2)
-        else:
-            dz = np.diff(z_values, axis=1, prepend=0)
-            dz = np.tile(dz, (model.num_subcolumns, 1, 1))
-            model.ds["sub_col_OD_%s_conv" % hyd_type] = np.flip(np.cumsum(
-                dz * model.ds["sub_col_alpha_p_%s_strat" % hyd_type], axis=2), axis=2)
             model.ds["sub_col_beta_p_%s_strat" % hyd_type].attrs["long_name"] = \
                 "Backscatter coefficient from %s in stratiform clouds" % hyd_names_dict[hyd_type]
             model.ds["sub_col_beta_p_%s_strat" % hyd_type].attrs["units"] = "m^-1"
@@ -290,4 +277,34 @@ def calc_lidar_moments(instrument, model, is_conv, ext_OD=10,
         model.ds["sub_col_OD_tot_strat"].attrs["long_name"] = \
             "Optical depth from all hydrometeors in stratiform clouds"
         model.ds["sub_col_OD_tot_strat"].attrs["units"] = "1"
+
         return model
+
+
+def _calc_strat_lidar_properties(tt, N_0, lambdas, mu, p_diam, total_hydrometeor,
+                                 hyd_type, num_subcolumns, dD, beta_p, alpha_p):
+    Dims = total_hydrometeor.shape
+    beta_p_strat = np.zeros((num_subcolumns, Dims[1]))
+    alpha_p_strat = np.zeros((num_subcolumns, Dims[1]))
+
+    if tt % 50 == 0:
+        print('Stratiform moment for class %s progress: %d/%d' % (hyd_type, tt, Dims[1]))
+    for k in range(Dims[1]):
+        if total_hydrometeor.values[tt, k] == 0:
+            continue
+        N_D = []
+        for i in range(num_subcolumns):
+            N_0_tmp = N_0[i, tt, k]
+            lambda_tmp = lambdas[i, tt, k]
+            mu_temp = mu[i, tt, k]
+            N_D.append(N_0_tmp * p_diam ** mu_temp * np.exp(-lambda_tmp * p_diam))
+        N_D = np.stack(N_D, axis=0)
+
+        Calc_tmp = np.tile(beta_p, (num_subcolumns, 1)) * N_D
+        beta_p_strat[:, k] = (
+            Calc_tmp[:, :].sum(axis=1) / 2 + Calc_tmp[:, 1:-1].sum(axis=1)) * dD
+        Calc_tmp = np.tile(alpha_p, (num_subcolumns, 1)) * N_D
+        alpha_p_strat[:, k] = (
+            Calc_tmp[:, :].sum(axis=1) / 2 + Calc_tmp[:, 1:-1].sum(axis=1)) * dD
+
+    return beta_p_strat, alpha_p_strat

--- a/emc2/simulator/main.py
+++ b/emc2/simulator/main.py
@@ -1,6 +1,6 @@
 from .subcolumn import set_convective_sub_col_frac, set_precip_sub_col_frac
 from .subcolumn import set_stratiform_sub_col_frac, set_q_n
-from .lidar_moments import calc_lidar_moments
+from .lidar_moments import calc_lidar_moments, calc_LDR
 from .radar_moments import calc_radar_moments
 
 
@@ -45,6 +45,17 @@ def make_simulated_data(model, instrument, N_columns, **kwargs):
         print("Generating lidar moments...")
         model = calc_lidar_moments(instrument, model, False, **kwargs)
         model = calc_lidar_moments(instrument, model, True, **kwargs)
+        if 'ext_OD' in kwargs.keys():
+            ext_OD = kwargs['ext_OD']
+        else:
+            ext_OD = 10.
+
+        if 'OD_from_sfc' in kwargs.keys():
+            OD_from_sfc = kwargs['OD_from_sfc']
+        else:
+            OD_from_sfc = True
+
+        model = calc_LDR(model, ext_OD=ext_OD, OD_from_sfc=OD_from_sfc)
     else:
         raise ValueError("Currently, only lidars and radars are supported as instruments.")
     return model

--- a/emc2/simulator/radar_moments.py
+++ b/emc2/simulator/radar_moments.py
@@ -1,5 +1,7 @@
 import xarray as xr
 import numpy as np
+import dask.bag as db
+import dask.array as da
 
 from ..core import Instrument, Model
 from .attenuation import calc_radar_atm_attenuation
@@ -61,7 +63,7 @@ def calc_radar_reflectivity_conv(instrument, model, hyd_type):
 
 
 def calc_radar_moments(instrument, model, is_conv,
-                       OD_from_sfc=True, **kwargs):
+                       OD_from_sfc=True, parallel=True, **kwargs):
     """
     Calculates the reflectivity, doppler velocity, and spectral width
     in a given column for the given radar.
@@ -78,6 +80,8 @@ def calc_radar_moments(instrument, model, is_conv,
         The name of the altitude field to use.
     OD_from_sfc: bool
         If True, then calculate optical depth from the surface.
+    parallel: bool
+        If True, then use parallelism to calculate each column quantity.
     Additional keyword arguments are passed into
     :func:`emc2.simulator.reflectivity.calc_radar_reflectivity_conv` and
     :func:`emc2.simulator.attenuation.calc_radar_atm_attenuation`.
@@ -88,6 +92,8 @@ def calc_radar_moments(instrument, model, is_conv,
         The xarray Dataset containing the calculated radar moments.
     """
 
+    # We don't care about invalid value errors
+    np.seterr(divide='ignore', invalid='ignore')
     hyd_types = ["cl", "ci", "pl", "pi"]
     hyd_names_dict = {'cl': 'cloud liquid particles', 'pl': 'liquid precipitation',
                       'ci': 'cloud ice particles', 'pi': 'liquid ice precipitation'}
@@ -164,9 +170,9 @@ def calc_radar_moments(instrument, model, is_conv,
     sigma_d_numer_tot = np.zeros(Dims)
     od_tot = np.zeros(Dims)
 
-    for hyd_type in ["pi", "pl", "ci", "cl"]:
+    for hyd_type in ["cl", "pl", "ci", "pi"]:
         num_diam = len(instrument.mie_table[hyd_type]["p_diam"].values)
-        if hyd_type == "pi":
+        if hyd_type == "cl":
             column_ds["sub_col_Ze_tot_strat"] = xr.DataArray(
                 np.zeros(Dims), dims=column_ds.strat_q_subcolumns_cl.dims)
             column_ds["sub_col_Vd_tot_strat"] = xr.DataArray(
@@ -183,85 +189,126 @@ def calc_radar_moments(instrument, model, is_conv,
             instrument.mie_table[hyd_type]["p_diam"].values[0]
         fits_ds = calc_mu_lambda(model, hyd_type, subcolumns=True, **kwargs).ds
         total_hydrometeor = column_ds[frac_names[hyd_type]] * column_ds[n_names[hyd_type]]
+        p_diam = instrument.mie_table[hyd_type]["p_diam"].values
+        alpha_p = instrument.mie_table[hyd_type]["alpha_p"].values
+        beta_p = instrument.mie_table[hyd_type]["beta_p"].values
+        num_subcolumns = model.num_subcolumns
+        v_tmp = model.vel_param_a[hyd_type] * p_diam ** model.vel_param_b[hyd_type]
+        v_tmp = v_tmp.magnitude
         if hyd_type == "cl":
-            for tt in range(Dims[1]):
-                if tt % 100 == 0:
-                    print('Stratiform moment for class %s progress: %d/%d' % (hyd_type, tt, Dims[1]))
-                for k in range(Dims[2]):
-                    if total_hydrometeor.values[tt, k] == 0:
-                        continue
+            tt_bag = db.from_sequence(np.arange(0, Dims[1], 1))
+            N_0 = fits_ds["N_0"].values
+            lambdas = fits_ds["lambda"].values
+            mu = fits_ds["mu"].values
 
-                    N_0_tmp = fits_ds["N_0"][:, tt, k].values.max(axis=0) * np.ones(
-                        (model.num_subcolumns, num_diam))
-                    lambda_tmp = fits_ds["lambda"][:, tt, k].values.max(axis=0) * np.ones(
-                        (model.num_subcolumns, num_diam))
-                    p_diam = (instrument.mie_table[hyd_type]["p_diam"].values * 2)
-                    p_diam_tiled = np.tile(
-                        instrument.mie_table[hyd_type]["p_diam"], (model.num_subcolumns, 1))
-                    mu_temp = np.tile(fits_ds["mu"].values[:, tt, k], (num_diam, 1)).T
-                    N_D = N_0_tmp * p_diam_tiled ** mu_temp * np.exp(-lambda_tmp * p_diam_tiled)
-                    Calc_tmp = instrument.mie_table[hyd_type]["beta_p"].values * N_D
-                    tmp_od = instrument.mie_table[hyd_type]["alpha_p"].values * N_D
-                    tmp_od = (tmp_od.sum(axis=1) / 2.0 + tmp_od[:, 1:-1].sum(axis=1)) * dD
-                    moment_denom = (Calc_tmp.sum(axis=1) / 2.0 + Calc_tmp[:, 1:-1].sum(axis=1)) * dD
-                    moment_denom = moment_denom.astype('float64')
-                    column_ds["sub_col_Ze_%s_strat" % hyd_type][:, tt, k] = \
-                        (moment_denom * instrument.wavelength**4) / (instrument.K_w * np.pi**5) * 1e-6
+            _calc_liquid = lambda x: _calculate_observables_liquid(x, total_hydrometeor, N_0, lambdas, mu,
+                                  alpha_p, beta_p, v_tmp, num_subcolumns, instrument, dD, p_diam)
+            if parallel:
+                my_tuple = tt_bag.map(_calc_liquid).compute()
+            else:
+                my_tuple = [x for x in map(_calc_liquid, np.arange(0, Dims[1], 1))]
 
-                    v_tmp = model.vel_param_a[hyd_type] * p_diam**model.vel_param_b[hyd_type]
-                    v_tmp = v_tmp.magnitude
-                    Calc_tmp2 = v_tmp * Calc_tmp.astype('float64')
-                    V_d_numer = (Calc_tmp2.sum(axis=1) / 2.0 + Calc_tmp2[:, 1:-1].sum(axis=1)) * dD
-                    column_ds["sub_col_Vd_%s_strat" % hyd_type][:, tt, k] = -V_d_numer / moment_denom
-                    Calc_tmp2 = (v_tmp -
-                                 np.tile(column_ds["sub_col_Vd_%s_strat" % hyd_type][:, tt, k].values,
-                                         (num_diam, 1)).T) ** 2 * Calc_tmp
-                    sigma_d_numer = (Calc_tmp2.sum(axis=1) / 2.0 + Calc_tmp2[:, 1:-1].sum(axis=1)) * dD
-                    column_ds["sub_col_sigma_d_%s_strat" % hyd_type][:, tt, k] = \
-                        np.sqrt(sigma_d_numer / moment_denom)
-                    V_d_numer_tot[:, tt, k] += V_d_numer
-                    moment_denom_tot[:, tt, k] += moment_denom
-                    od_tot[:, tt, k] += tmp_od
+            V_d_numer_tot = np.nan_to_num(np.stack([x[0] for x in my_tuple], axis=1))
+            moment_denom_tot = np.nan_to_num(np.stack([x[1] for x in my_tuple], axis=1))
+            od_tot = np.nan_to_num(np.stack([x[2] for x in my_tuple], axis=1))
+
+            column_ds["sub_col_Ze_cl_strat"][:, :, :] = np.stack([x[3] for x in my_tuple], axis=1)
+            column_ds["sub_col_Vd_cl_strat"][:, :, :] = np.stack([x[4] for x in my_tuple], axis=1)
+            column_ds["sub_col_sigma_d_cl_strat"][:, :, :] = np.stack([x[5] for x in my_tuple], axis=1)
+            del my_tuple
+            # for tt in range(Dims[1]):
+            #     if tt % 100 == 0:
+            #         print('Stratiform moment for class %s progress: %d/%d' % (hyd_type, tt, Dims[1]))
+            #     for k in range(Dims[2]):
+            #         if total_hydrometeor.values[tt, k] == 0:
+            #             continue
+            #
+            #         N_0_tmp = fits_ds["N_0"][:, tt, k].values.max(axis=0) * np.ones(
+            #             (model.num_subcolumns, num_diam))
+            #         lambda_tmp = fits_ds["lambda"][:, tt, k].values.max(axis=0) * np.ones(
+            #             (model.num_subcolumns, num_diam))
+            #         p_diam = (instrument.mie_table[hyd_type]["p_diam"].values * 2)
+            #         p_diam_tiled = np.tile(
+            #             instrument.mie_table[hyd_type]["p_diam"], (model.num_subcolumns, 1))
+            #         mu_temp = np.tile(fits_ds["mu"].values[:, tt, k], (num_diam, 1)).T
+            #         N_D = N_0_tmp * p_diam_tiled ** mu_temp * np.exp(-lambda_tmp * p_diam_tiled)
+            #         Calc_tmp = instrument.mie_table[hyd_type]["beta_p"].values * N_D
+            #         tmp_od = instrument.mie_table[hyd_type]["alpha_p"].values * N_D
+            #         tmp_od = (tmp_od.sum(axis=1) / 2.0 + tmp_od[:, 1:-1].sum(axis=1)) * dD
+            #         moment_denom = (Calc_tmp.sum(axis=1) / 2.0 + Calc_tmp[:, 1:-1].sum(axis=1)) * dD
+            #         moment_denom = moment_denom.astype('float64')
+            #         column_ds["sub_col_Ze_%s_strat" % hyd_type][:, tt, k] = \
+            #             (moment_denom * instrument.wavelength**4) / (instrument.K_w * np.pi**5) * 1e-6
+            #
+            #         v_tmp = model.vel_param_a[hyd_type] * p_diam**model.vel_param_b[hyd_type]
+            #         v_tmp = v_tmp.magnitude
+            #         Calc_tmp2 = v_tmp * Calc_tmp.astype('float64')
+            #         V_d_numer = (Calc_tmp2.sum(axis=1) / 2.0 + Calc_tmp2[:, 1:-1].sum(axis=1)) * dD
+            #         column_ds["sub_col_Vd_%s_strat" % hyd_type][:, tt, k] = -V_d_numer / moment_denom
+            #         Calc_tmp2 = (v_tmp -
+            #                      np.tile(column_ds["sub_col_Vd_%s_strat" % hyd_type][:, tt, k].values,
+            #                              (num_diam, 1)).T) ** 2 * Calc_tmp
+            #         sigma_d_numer = (Calc_tmp2.sum(axis=1) / 2.0 + Calc_tmp2[:, 1:-1].sum(axis=1)) * dD
+            #         column_ds["sub_col_sigma_d_%s_strat" % hyd_type][:, tt, k] = \
+            #             np.sqrt(sigma_d_numer / moment_denom)
+            #         V_d_numer_tot[:, tt, k] += V_d_numer
+            #         moment_denom_tot[:, tt, k] += moment_denom
+            #         od_tot[:, tt, k] += tmp_od
         else:
-            p_diam_tiled = np.tile(
-                instrument.mie_table[hyd_type]["p_diam"], (model.num_subcolumns, 1))
+            print("Doing parallel calculation for %s" % hyd_type)
+            tt_bag = db.from_sequence(np.arange(0, Dims[1], 1))
             sub_q_array = column_ds["strat_q_subcolumns_%s" % hyd_type].values
-            v_tmp = model.vel_param_a[hyd_type] * p_diam_tiled ** model.vel_param_b[hyd_type]
-
-            for tt in range(Dims[1]):
-                if tt % 50 == 0:
-                    print('Stratiform moment for class %s progress: %d/%d' % (hyd_type, tt, Dims[1]))
-                for k in range(Dims[2]):
-                    if total_hydrometeor.values[tt, k] == 0:
-                        continue
-                    N_0_tmp = fits_ds["N_0"][:, tt, k].values.max(axis=0)
-                    lambda_tmp = fits_ds["lambda"][:, tt, k].values.max(axis=0)
-                    mu = fits_ds["mu"][:, tt, k].values.max(axis=0)
-                    N_D = N_0_tmp * np.exp(-lambda_tmp * p_diam_tiled) * p_diam_tiled**mu
-                    Calc_tmp = np.tile(instrument.mie_table[hyd_type]["beta_p"].values,
-                                       (model.num_subcolumns, 1)) * N_D
-                    tmp_od = np.tile(
-                        instrument.mie_table[hyd_type]["alpha_p"].values, (model.num_subcolumns, 1)) * N_D
-                    tmp_od = (tmp_od.sum(axis=1) / 2 + tmp_od[:, 1:-1].sum(axis=1)) * dD
-                    tmp_od = np.where(sub_q_array[:, tt, k] == 0, 0, tmp_od)
-                    moment_denom = (Calc_tmp.sum(axis=1) / 2. + Calc_tmp[:, 1:-1].sum(axis=1)) * dD
-                    moment_denom = np.where(sub_q_array[:, tt, k] == 0, np.nan, moment_denom)
-                    column_ds["sub_col_Ze_%s_strat" % hyd_type][:, tt, k] = \
-                        (moment_denom * instrument.wavelength ** 4) / (instrument.K_w * np.pi ** 5) * 1e-6
-                    Calc_tmp2 = Calc_tmp * v_tmp.magnitude
-                    V_d_numer = (Calc_tmp2.sum(axis=1) / 2. + Calc_tmp2[:, 1:-1].sum(axis=1)) * dD
-                    V_d_numer = np.where(sub_q_array[:, tt, k] == 0, np.nan, V_d_numer)
-                    column_ds["sub_col_Vd_%s_strat" % hyd_type][:, tt, k] = -V_d_numer / moment_denom
-                    Calc_tmp2 = (v_tmp.magnitude - np.tile(
-                        column_ds["sub_col_Vd_%s_strat" % hyd_type][:, tt, k].values,
-                        (num_diam, 1)).T)**2 * Calc_tmp
-                    Calc_tmp2 = (Calc_tmp2.sum(axis=1) / 2. + Calc_tmp2[:, 1:-1].sum(axis=1)) * dD
-                    sigma_d_numer = np.where(sub_q_array[:, tt, k] == 0, np.nan, Calc_tmp2)
-                    column_ds["sub_col_sigma_d_%s_strat" % hyd_type][:, tt, k] = \
-                        np.sqrt(sigma_d_numer / moment_denom)
-                    V_d_numer_tot[:, tt, k] += V_d_numer
-                    moment_denom_tot[:, tt, k] += moment_denom
-                    od_tot[:, tt, k] += tmp_od
+            _calc_other = lambda x: _calculate_other_observables(
+                x, total_hydrometeor, fits_ds, model, instrument, sub_q_array, hyd_type, dD)
+            if parallel:
+                my_tuple = tt_bag.map(_calc_other).compute()
+            else:
+                my_tuple = [x for x in map(_calc_other, np.arange(0, Dims[1], 1))]
+            V_d_numer_tot += np.nan_to_num(np.stack([x[0] for x in my_tuple], axis=1))
+            moment_denom_tot += np.nan_to_num(np.stack([x[1] for x in my_tuple], axis=1))
+            od_tot = np.nan_to_num(np.stack([x[2] for x in my_tuple], axis=1))
+            column_ds["sub_col_Ze_%s_strat" % hyd_type][:, :, :] = np.stack([x[3] for x in my_tuple], axis=1)
+            column_ds["sub_col_Vd_%s_strat" % hyd_type][:, :, :] = np.stack([x[4] for x in my_tuple], axis=1)
+            column_ds["sub_col_sigma_d_%s_strat" % hyd_type][:, :, :] = np.stack([x[5] for x in my_tuple], axis=1)
+            # p_diam_tiled = np.tile(
+            #     instrument.mie_table[hyd_type]["p_diam"], (model.num_subcolumns, 1))
+            #
+            # v_tmp = model.vel_param_a[hyd_type] * p_diam_tiled ** model.vel_param_b[hyd_type]
+            #
+            # for tt in range(Dims[1]):
+            #     if tt % 50 == 0:
+            #         print('Stratiform moment for class %s progress: %d/%d' % (hyd_type, tt, Dims[1]))
+            #     for k in range(Dims[2]):
+            #         if total_hydrometeor.values[tt, k] == 0:
+            #             continue
+            #         N_0_tmp = fits_ds["N_0"][:, tt, k].values.max(axis=0)
+            #         lambda_tmp = fits_ds["lambda"][:, tt, k].values.max(axis=0)
+            #         mu = fits_ds["mu"][:, tt, k].values.max(axis=0)
+            #         N_D = N_0_tmp * np.exp(-lambda_tmp * p_diam_tiled) * p_diam_tiled ** mu
+            #         Calc_tmp = np.tile(instrument.mie_table[hyd_type]["beta_p"].values,
+            #                            (model.num_subcolumns, 1)) * N_D
+            #         tmp_od = np.tile(
+            #             instrument.mie_table[hyd_type]["alpha_p"].values, (model.num_subcolumns, 1)) * N_D
+            #         tmp_od = (tmp_od.sum(axis=1) / 2 + tmp_od[:, 1:-1].sum(axis=1)) * dD
+            #         tmp_od = np.where(sub_q_array[:, tt, k] == 0, 0, tmp_od)
+            #         moment_denom = (Calc_tmp.sum(axis=1) / 2. + Calc_tmp[:, 1:-1].sum(axis=1)) * dD
+            #         moment_denom = np.where(sub_q_array[:, tt, k] == 0, np.nan, moment_denom)
+            #         column_ds["sub_col_Ze_%s_strat" % hyd_type][:, tt, k] = \
+            #             (moment_denom * instrument.wavelength ** 4) / (instrument.K_w * np.pi ** 5) * 1e-6
+            #         Calc_tmp2 = Calc_tmp * v_tmp.magnitude
+            #         V_d_numer = (Calc_tmp2.sum(axis=1) / 2. + Calc_tmp2[:, 1:-1].sum(axis=1)) * dD
+            #         V_d_numer = np.where(sub_q_array[:, tt, k] == 0, np.nan, V_d_numer)
+            #         column_ds["sub_col_Vd_%s_strat" % hyd_type][:, tt, k] = -V_d_numer / moment_denom
+            #         Calc_tmp2 = (v_tmp.magnitude - np.tile(
+            #             column_ds["sub_col_Vd_%s_strat" % hyd_type][:, tt, k].values,
+            #             (num_diam, 1)).T) ** 2 * Calc_tmp
+            #         Calc_tmp2 = (Calc_tmp2.sum(axis=1) / 2. + Calc_tmp2[:, 1:-1].sum(axis=1)) * dD
+            #         sigma_d_numer = np.where(sub_q_array[:, tt, k] == 0, np.nan, Calc_tmp2)
+            #         column_ds["sub_col_sigma_d_%s_strat" % hyd_type][:, tt, k] = \
+            #             np.sqrt(sigma_d_numer / moment_denom)
+            #         V_d_numer_tot[:, tt, k] += V_d_numer
+            #         moment_denom_tot[:, tt, k] += moment_denom
+            #         od_tot[:, tt, k] += tmp_od
 
         if "sub_col_Ze_tot_strat" in column_ds.variables.keys():
             column_ds["sub_col_Ze_tot_strat"] += column_ds["sub_col_Ze_%s_strat" % hyd_type].fillna(0)
@@ -273,8 +320,7 @@ def calc_radar_moments(instrument, model, is_conv,
             column_ds["sub_col_Vd_%s_strat" % hyd_type] != 0)
         column_ds["sub_col_sigma_d_%s_strat" % hyd_type] = column_ds["sub_col_Vd_%s_strat" % hyd_type].where(
             column_ds["sub_col_sigma_d_%s_strat" % hyd_type] != 0)
-        column_ds["sub_col_Vd_tot_strat"] = xr.DataArray(-V_d_numer_tot / moment_denom_tot,
-                                                         dims=column_ds["sub_col_Ze_tot_strat"].dims)
+
 
         column_ds["sub_col_Ze_%s_strat" % hyd_type].attrs["long_name"] = \
             "Radar reflectivity factor from %s in stratiform clouds" % hyd_names_dict[hyd_type]
@@ -286,58 +332,33 @@ def calc_radar_moments(instrument, model, is_conv,
             "Spectral width from %s in stratiform clouds" % hyd_names_dict[hyd_type]
         column_ds["sub_col_sigma_d_%s_strat" % hyd_type].attrs["units"] = "m s-1"
         print("Generating stratiform radar moments for hydrometeor class %s" % hyd_type)
+    column_ds["sub_col_Vd_tot_strat"] = xr.DataArray(-V_d_numer_tot / moment_denom_tot,
+                                                     dims=column_ds["sub_col_Ze_tot_strat"].dims)
+    for hyd_type in ["cl", "pl", "ci", "pi"]:
         if hyd_type == "cl":
-            for tt in range(Dims[1]):
-                if tt % 50 == 0:
-                    print('Stratiform moment for class %s progress: %d/%d' % (hyd_type, tt, Dims[1]))
-                for k in range(Dims[2]):
-                    if total_hydrometeor.values[tt, k] == 0:
-                        continue
-                    N_0_tmp = fits_ds["N_0"].values[:, tt, k]
-                    p_diam = instrument.mie_table[hyd_type]["p_diam"].values
-                    N_0_tmp, d_diam_tmp = np.meshgrid(N_0_tmp, p_diam)
-                    lambda_tmp = fits_ds["lambda"].values[:, tt, k]
-                    lambda_tmp, d_diam_tmp = np.meshgrid(lambda_tmp, p_diam)
-                    mu_temp = fits_ds["mu"].values[:, tt, k] * np.ones_like(lambda_tmp)
-                    N_D = N_0_tmp * d_diam_tmp ** mu_temp * np.exp(-lambda_tmp * d_diam_tmp)
-                    Calc_tmp = np.tile(
-                        instrument.mie_table[hyd_type]["beta_p"].values, (model.num_subcolumns, 1)) * N_D.T
-                    moment_denom = (Calc_tmp.sum(axis=1) / 2.0 + Calc_tmp[:, 1:-1].sum(axis=1)) * dD
-                    v_tmp = model.vel_param_a[hyd_type] * p_diam ** model.vel_param_b[hyd_type]
-                    v_tmp = v_tmp.magnitude
-                    Calc_tmp2 = (v_tmp - np.tile(
-                        column_ds["sub_col_Vd_tot_strat"][:, tt, k].values, (num_diam, 1)).T) ** 2 * Calc_tmp
-                    sigma_d_numer = (Calc_tmp2.sum(axis=1) / 2.0 + Calc_tmp2[:, 1:-1].sum(axis=1)) * dD
-                    column_ds["sub_col_sigma_d_tot_strat"][:, tt, k] = np.sqrt(sigma_d_numer / moment_denom)
+            print("Doing parallel calculation for %s" % hyd_type)
+            tt_bag = db.from_sequence(np.arange(0, Dims[1], 1))
+            Vd_tot = column_ds["sub_col_Vd_tot_strat"].values
+            _calc_sigma_d_liq = lambda x: _calc_sigma_d_tot_cl(
+                x, fits_ds, instrument, model, total_hydrometeor, dD, Vd_tot)
+            if parallel:
+                sigma_d_numer = tt_bag.map(_calc_sigma_d_liq).compute()
+            else:
+                sigma_d_numer = [x for x in map(_calc_sigma_d_liq, np.arange(0, Dims[1], 1))]
 
+            sigma_d_numer = np.stack(sigma_d_numer, axis=1)
+            sigma_d_numer_tot = sigma_d_numer
         else:
-            mu = fits_ds["mu"].values.max()
-            p_diam_tiled = np.tile(
-                instrument.mie_table[hyd_type]["p_diam"], (model.num_subcolumns, 1))
-            v_tmp = model.vel_param_a[hyd_type] * p_diam_tiled ** model.vel_param_b[hyd_type]
-            v_tmp = v_tmp.magnitude
             sub_q_array = column_ds["strat_q_subcolumns_%s" % hyd_type].values
-            for tt in range(Dims[1]):
-                if tt % 50 == 0:
-                    print('Stratiform moment for class %s progress: %d/%d' % (hyd_type, tt, Dims[1]))
-                for k in range(Dims[2]):
-                    if total_hydrometeor.values[tt, k] == 0:
-                        continue
-                    N_0_tmp = fits_ds["N_0"][:, tt, k].values.max(axis=0)
-                    lambda_tmp = fits_ds["lambda"][:, tt, k].values.max(axis=0)
-                    N_D = N_0_tmp * p_diam_tiled ** mu * np.exp(-lambda_tmp * p_diam_tiled)
-                    Calc_tmp = np.tile(
-                        instrument.mie_table[hyd_type]["beta_p"].values,
-                        (model.num_subcolumns, 1)) * N_D
-                    moment_denom = (Calc_tmp.sum(axis=1) / 2. + Calc_tmp[:, 1:-1].sum(axis=1)) * dD
-                    moment_denom = np.where(sub_q_array[:, tt, k] == 0, 0, moment_denom)
-                    Calc_tmp2 = (v_tmp - np.tile(
-                        column_ds["sub_col_Vd_tot_strat"][:, tt, k].values, (num_diam, 1)).T) ** 2 * Calc_tmp
-                    Calc_tmp2 = (Calc_tmp2.sum(axis=1) / 2. + Calc_tmp2[:, 1:-1].sum(axis=1)) * dD
-                    sigma_d_numer = np.where(sub_q_array[:, tt, k] == 0, 0, Calc_tmp2)
-                    column_ds["sub_col_sigma_d_%s_strat" % hyd_type][:, tt, k] = \
-                        np.sqrt(sigma_d_numer / moment_denom)
-                    sigma_d_numer_tot[:, tt, k] += sigma_d_numer
+            _calc_sigma = lambda x: _calc_sigma_d_tot(
+                x, model, p_diam, v_tmp, fits_ds, total_hydrometeor, Vd_tot, sub_q_array, dD)
+            if parallel:
+                sigma_d_numer = tt_bag.map(_calc_sigma).compute()
+            else:
+                sigma_d_numer = [x for x in map(_calc_sigma, np.arange(0, Dims[1], 1))]
+            sigma_d_numer = np.stack(sigma_d_numer, axis=1)
+            sigma_d_numer_tot += sigma_d_numer
+
 
     column_ds["sub_col_sigma_d_tot_strat"] = xr.DataArray(np.sqrt(sigma_d_numer_tot / moment_denom_tot),
                                                           dims=column_ds["sub_col_Vd_tot_strat"].dims)
@@ -368,7 +389,7 @@ def calc_radar_moments(instrument, model, is_conv,
         column_ds['sub_col_sigma_d_tot_strat'] != 0)
 
     column_ds['sub_col_Ze_att_tot_strat'].attrs["long_name"] = \
-        "Radar reflectivity factor in stratiform clouds factoring in gaseous atteunation"
+        "Radar reflectivity factor in stratiform clouds factoring in gaseous attenuation"
     column_ds['sub_col_Ze_att_tot_strat'].attrs["units"] = "dBZ"
     column_ds['sub_col_Ze_tot_strat'].attrs["long_name"] = \
         "Radar reflectivity factor in stratiform clouds"
@@ -382,3 +403,155 @@ def calc_radar_moments(instrument, model, is_conv,
     model.ds = column_ds
 
     return model
+
+def _calc_sigma_d_tot_cl(tt, fits_ds, instrument, model, total_hydrometeor, dD, Vd_tot):
+    hyd_type = "cl"
+    sigma_d_numer = np.zeros((model.num_subcolumns, total_hydrometeor.shape[1]))
+    if tt % 50 == 0:
+        print('Stratiform moment for class cl progress: %d/%d' % (tt, total_hydrometeor.shape[1]))
+    p_diam = instrument.mie_table[hyd_type]["p_diam"].values
+    num_diam = len(p_diam)
+    Dims = Vd_tot.shape
+    for k in range(Dims[2]):
+        if total_hydrometeor.values[tt, k] == 0:
+            continue
+        N_0_tmp = fits_ds["N_0"].values[:, tt, k]
+        N_0_tmp, d_diam_tmp = np.meshgrid(N_0_tmp, p_diam)
+        lambda_tmp = fits_ds["lambda"].values[:, tt, k]
+        lambda_tmp, d_diam_tmp = np.meshgrid(lambda_tmp, p_diam)
+        mu_temp = fits_ds["mu"].values[:, tt, k] * np.ones_like(lambda_tmp)
+        N_D = N_0_tmp * d_diam_tmp ** mu_temp * np.exp(-lambda_tmp * d_diam_tmp)
+        Calc_tmp = np.tile(
+            instrument.mie_table[hyd_type]["beta_p"].values, (model.num_subcolumns, 1)) * N_D.T
+        v_tmp = model.vel_param_a[hyd_type] * p_diam ** model.vel_param_b[hyd_type]
+        v_tmp = v_tmp.magnitude
+        Calc_tmp2 = (v_tmp - np.tile(Vd_tot[:, tt, k], (num_diam, 1)).T) ** 2 * Calc_tmp
+        sigma_d_numer[:, k] = (Calc_tmp2.sum(axis=1) / 2.0 + Calc_tmp2[:, 1:-1].sum(axis=1)) * dD
+
+    return sigma_d_numer
+
+def _calc_sigma_d_tot(tt, model, p_diam, v_tmp, fits_ds, total_hydrometeor, vd_tot, sub_q_array, dD):
+    Dims = vd_tot.shape
+    sigma_d_numer = np.zeros((model.num_subcolumns, total_hydrometeor.shape[1]))
+
+    num_diam = len(p_diam)
+    mu = fits_ds["mu"].values.max()
+    if tt % 50 == 0:
+            print('Stratiform moment for class progress: %d/%d' % (tt, Dims[1]))
+    for k in range(Dims[2]):
+        if total_hydrometeor.values[tt, k] == 0:
+            continue
+        N_0_tmp = fits_ds["N_0"][:, tt, k].values.max(axis=0)
+        lambda_tmp = fits_ds["lambda"][:, tt, k].values.max(axis=0)
+        if np.isnan(N_0_tmp):
+            continue
+        N_D = []
+        for i in range(model.num_subcolumns):
+            N_D.append(N_0_tmp * p_diam ** mu * np.exp(-lambda_tmp * p_diam))
+        N_D = np.stack(N_D, axis=1)
+        Calc_tmp = np.tile(
+            instrument.mie_table[hyd_type]["beta_p"].values,
+            (model.num_subcolumns, 1)) * N_D
+        Calc_tmp2 = (v_tmp - np.tile(vd_tot[:, tt, k], (num_diam, 1)).T) ** 2 * Calc_tmp
+        Calc_tmp2 = (Calc_tmp2.sum(axis=1) / 2. + Calc_tmp2[:, 1:-1].sum(axis=1)) * dD
+        sigma_d_numer[:, k] = np.where(sub_q_array[:, tt, k] == 0, 0, Calc_tmp2)
+
+    return sigma_d_numer
+
+def _calculate_observables_liquid(tt, total_hydrometeor, N_0, lambdas, mu,
+                                  alpha_p, beta_p, v_tmp, num_subcolumns, instrument, dD, p_diam):
+    hyd_type = 'cl'
+    height_dims = N_0.shape[2]
+    V_d_numer_tot = np.zeros((num_subcolumns, height_dims))
+    V_d = np.nan * np.ones((num_subcolumns, height_dims))
+    Ze = np.nan * np.ones_like(V_d)
+    sigma_d = np.nan * np.ones_like(V_d)
+    moment_denom_tot = np.zeros_like(V_d_numer_tot)
+    od_tot = np.zeros_like(V_d_numer_tot)
+    num_diam = len(p_diam)
+    if tt % 50 == 0:
+        print("Processing column %d" % tt)
+    np.seterr(all="ignore")
+    for k in range(height_dims):
+        if total_hydrometeor.values[tt, k] == 0:
+            continue
+
+        N_0_tmp = N_0[:, tt, k].max(axis=0)
+        lambda_tmp = lambdas[:, tt, k].max(axis=0)
+        if np.isnan(N_0_tmp):
+            continue
+        p_diam2 = (p_diam * 2)
+        mu_temp = mu[:, tt, k]
+        N_D = []
+        for i in range(num_subcolumns):
+            N_D.append(N_0_tmp * p_diam2 ** mu_temp[i] * np.exp(-lambda_tmp * p_diam2))
+        N_D = np.stack(N_D, axis=0)
+
+        Calc_tmp = beta_p * N_D
+        tmp_od = np.trapz(alpha_p * N_D, dx=dD)
+        moment_denom = np.trapz(Calc_tmp, dx=dD, axis=1).astype('float64')
+        Ze[:, k] = \
+            (moment_denom * instrument.wavelength ** 4) / (instrument.K_w * np.pi ** 5) * 1e-6
+
+        Calc_tmp2 = v_tmp * Calc_tmp.astype('float64')
+        V_d_numer = np.trapz(Calc_tmp2, dx=dD, axis=1)
+        V_d[:, k] = -V_d_numer / moment_denom
+        Calc_tmp2 = (v_tmp - np.tile(V_d[:, k], (num_diam, 1)).T) ** 2 * Calc_tmp
+        sigma_d_numer = np.trapz(Calc_tmp2, dx=dD, axis=1)
+        sigma_d[:, k] = np.sqrt(sigma_d_numer / moment_denom)
+        V_d_numer_tot[:, k] += V_d_numer
+        moment_denom_tot[:, k] += moment_denom
+        od_tot[:, k] += tmp_od
+
+    return V_d_numer_tot, moment_denom_tot, od_tot, Ze, V_d, sigma_d
+
+def _calculate_other_observables(tt, total_hydrometeor, fits_ds, model, instrument, sub_q_array, hyd_type, dD):
+    Dims = sub_q_array.shape
+    if tt % 50 == 0:
+        print('Stratiform moment for class %s progress: %d/%d' % (hyd_type, tt, Dims[1]))
+    Ze = np.nan*np.ones((model.num_subcolumns, Dims[2]))
+    V_d = np.nan*np.ones_like(Ze)
+    sigma_d = np.nan*np.ones_like(Ze)
+    V_d_numer_tot = np.nan*np.ones_like(Ze)
+    moment_denom_tot = np.nan*np.ones_like(Ze)
+    od_tot = np.nan*np.ones_like(Ze)
+    for k in range(Dims[2]):
+        if total_hydrometeor.values[tt, k] == 0:
+            continue
+        N_0_tmp = fits_ds["N_0"][:, tt, k].values.max(axis=0)
+        lambda_tmp = fits_ds["lambda"][:, tt, k].values.max(axis=0)
+        if np.isnan(N_0_tmp):
+            continue
+        mu = fits_ds["mu"][:, tt, k].values.max(axis=0)
+        p_diam = (instrument.mie_table[hyd_type]["p_diam"].values * 2)
+        mu_temp = fits_ds["mu"].values[:, tt, k]
+        num_diam = len(p_diam)
+        N_D = []
+        for i in range(model.num_subcolumns):
+            N_D.append(N_0_tmp * p_diam ** mu_temp[i] * np.exp(-lambda_tmp * p_diam))
+        N_D = np.stack(N_D, axis=0)
+        Calc_tmp = np.tile(instrument.mie_table[hyd_type]["beta_p"].values,
+                           (model.num_subcolumns, 1)) * N_D
+        tmp_od = np.tile(
+            instrument.mie_table[hyd_type]["alpha_p"].values, (model.num_subcolumns, 1)) * N_D
+        tmp_od = np.trapz(tmp_od, dx=dD, axis=1)
+        tmp_od = np.where(sub_q_array[:, tt, k] == 0, 0, tmp_od)
+        moment_denom = np.trapz(Calc_tmp, dx=dD, axis=1)
+        moment_denom = np.where(sub_q_array[:, tt, k] == 0, np.nan, moment_denom)
+        Ze[:, k] = \
+            (moment_denom * instrument.wavelength ** 4) / (instrument.K_w * np.pi ** 5) * 1e-6
+        v_tmp = model.vel_param_a[hyd_type] * p_diam ** model.vel_param_b[hyd_type]
+        v_tmp = v_tmp.magnitude
+        Calc_tmp2 = Calc_tmp * v_tmp
+        V_d_numer = np.trapz(Calc_tmp2, axis=1, dx=dD)
+        V_d_numer = np.where(sub_q_array[:, tt, k] == 0, np.nan, V_d_numer)
+        V_d[:, k] = -V_d_numer / moment_denom
+        Calc_tmp2 = (v_tmp - np.tile(V_d[:, k], (num_diam, 1)).T) ** 2 * Calc_tmp
+        Calc_tmp2 = np.trapz(Calc_tmp2, axis=1, dx=dD)
+        sigma_d_numer = np.where(sub_q_array[:, tt, k] == 0, np.nan, Calc_tmp2)
+        sigma_d[:, k] = np.sqrt(sigma_d_numer / moment_denom)
+        V_d_numer_tot[:, k] += V_d_numer
+        moment_denom_tot[:, k] += moment_denom
+        od_tot[:, k] += tmp_od
+
+    return V_d_numer_tot, moment_denom_tot, od_tot, Ze, V_d, sigma_d

--- a/emc2/simulator/subcolumn.py
+++ b/emc2/simulator/subcolumn.py
@@ -24,7 +24,7 @@ def set_convective_sub_col_frac(model, hyd_type, N_columns=None):
     model: :py:func: `emc2.core.Model`
         The Model object with the convective fraction in each subcolumn added.
     """
-
+    np.seterr(divide='ignore', invalid='ignore')
     if model.num_subcolumns == 0 and N_columns is None:
         raise RuntimeError("The number of subcolumns must be specified in the model!")
 
@@ -79,7 +79,7 @@ def set_stratiform_sub_col_frac(model):
     if "conv_frac_subcolumns_ci" not in model.ds.variables.keys():
         raise KeyError("You have to generate the convective fraction in each subcolumn " +
                        "before the stratiform fraction in each subcolumn is generated.")
-
+    np.seterr(divide='ignore', invalid='ignore')
     conv_profs1 = model.ds["conv_frac_subcolumns_cl"]
     conv_profs2 = model.ds["conv_frac_subcolumns_ci"]
     N_columns = len(model.ds["subcolumn"])
@@ -218,7 +218,7 @@ def set_precip_sub_col_frac(model, convective=True, N_columns=None):
     model: :py:func: `emc2.core.Model`
         The Model object with the stratiform hydrometeor fraction in each subcolumn added.
     """
-
+    np.seterr(divide='ignore', invalid='ignore')
     if model.num_subcolumns == 0 and N_columns is None:
         raise RuntimeError("The number of subcolumns must be specified in the model!")
 
@@ -346,7 +346,7 @@ def set_q_n(model, hyd_type, is_conv=True, qc_flag=True, inv_rel_var=1):
     in the Community Atmosphere Model, Version 3 (CAM3). Part I: Description and Numerical Tests.
     J. Climate, 21, 3642–3659, https://doi.org/10.1175/2008JCLI2105.1
     """
-
+    np.seterr(divide='ignore', invalid='ignore')
     if model.num_subcolumns == 0:
         raise RuntimeError("The number of subcolumns must be specified in the model!")
 

--- a/tests/test_lidar_moments.py
+++ b/tests/test_lidar_moments.py
@@ -21,11 +21,12 @@ def test_radar_moments_all_convective():
     my_model = emc2.simulator.subcolumn.set_q_n(my_model, 'pl', is_conv=False, qc_flag=False)
     my_model = emc2.simulator.subcolumn.set_q_n(my_model, 'pi', is_conv=False, qc_flag=False)
     my_model = emc2.simulator.lidar_moments.calc_lidar_moments(instrument, my_model, True, 10)
-
+    my_model = emc2.simulator.lidar_moments.calc_lidar_moments(instrument, my_model, False, 10)
     # Check to see if the signal goes extinct. We should have thick enough cloud for this. OD should
     # increase with height
     assert np.all(np.logical_or(np.diff(my_model.ds['sub_col_OD_tot_conv'].values, axis=1) > 0,
                                 np.isnan(np.diff(my_model.ds['sub_col_OD_tot_conv'].values, axis=1))))
+    my_model = emc2.simulator.lidar_moments.calc_LDR(my_model)
     assert my_model.ds['ext_mask'].max() == 2
 
     # We should have all zeros
@@ -59,4 +60,4 @@ def test_radar_moments_all_stratiform():
 
     # We should have all zeros in convection
     my_model = emc2.simulator.lidar_moments.calc_lidar_moments(instrument, my_model, True, 10)
-    assert np.all(np.isnan(my_model.ds['sub_col_OD_tot_conv'].values))
+    assert np.all(my_model.ds['sub_col_OD_tot_conv'].values == 0)

--- a/tests/test_radar_moments.py
+++ b/tests/test_radar_moments.py
@@ -49,7 +49,7 @@ def test_radar_moments_all_stratiform():
     my_model = emc2.simulator.subcolumn.set_q_n(my_model, 'pi', is_conv=False, qc_flag=False)
     my_model = emc2.simulator.radar_moments.calc_radar_moments(instrument, my_model, False)
     assert np.nanmax(my_model.ds["sub_col_Ze_tot_strat"].values) < 80.
-    assert my_model.ds["sub_col_Ze_pl_strat"].values.max() < 80.
+    assert np.nanmax(my_model.ds["sub_col_Ze_pl_strat"].values) < 80.
     assert np.all(~np.isfinite(my_model.ds["sub_col_Ze_pi_strat"].values))
     assert np.all(~np.isfinite(my_model.ds["sub_col_Ze_ci_strat"].values))
     assert np.all(np.nanmax(np.abs(my_model.ds["sub_col_Vd_cl_strat"].values)) < 1)


### PR DESCRIPTION
EMC^2 now can process model time periods in parallel using dask! In addition, several fixes to the metadata have been applied. 

A bug where the total spectral width was being set to the total velocity has also been fixed.