### PR TITLE
FIX: ACT version compatibility when loading ARM NetCDF files

### DIFF
--- a/emc2/core/instrument.py
+++ b/emc2/core/instrument.py
@@ -119,7 +119,7 @@ class Instrument(object):
         ----------
         filename: str
 
-        Additional keyword arguments are passed into :py:func:`act.io.armfiles.read_netcdf`
+        Additional keyword arguments are passed into :py:func:`act.io.arm.read_arm_netcdf`
 
         """
         self.ds = load_arm_file(filename, **kwargs)

--- a/emc2/core/model.py
+++ b/emc2/core/model.py
@@ -9,7 +9,11 @@ This module contains the Model class and example Models for your use.
 import xarray as xr
 import numpy as np
 
-from act.io.armfiles import read_netcdf
+try:
+    from act.io.arm import read_arm_netcdf as read_netcdf
+except:
+    print('Using act-atmos v1.5.3 or earlier. Please update to v2.0.0 or newer')
+    from act.io.armfiles import read_netcdf
 from .instrument import ureg, quantity
 from netCDF4 import Dataset
 from ..scattering import brandes

--- a/emc2/io/load_obs.py
+++ b/emc2/io/load_obs.py
@@ -1,8 +1,8 @@
 try:
-    from act.io.arm import read_arm_netcdf
+    from act.io.arm import read_arm_netcdf as read_netcdf
 except:
     print('Using act-atmos v1.5.3 or earlier. Please update to v2.0.0 or newer')
-    from act.io.armfiles import read_netcdf as read_arm_netcdf
+    from act.io.armfiles import read_netcdf
 
 
 def load_arm_file(filename, **kwargs):
@@ -22,4 +22,4 @@ def load_arm_file(filename, **kwargs):
         The xarray dataset containing the file data.
     """
 
-    return read_arm_netcdf(filename, **kwargs)
+    return read_netcdf(filename, **kwargs)

--- a/emc2/io/load_obs.py
+++ b/emc2/io/load_obs.py
@@ -1,4 +1,8 @@
-from act.io.armfiles import read_netcdf
+try:
+    from act.io.arm import read_arm_netcdf
+except:
+    print('Using act-atmos v1.5.3 or earlier. Please update to v2.0.0 or newer')
+    from act.io.armfiles import read_netcdf as read_arm_netcdf
 
 
 def load_arm_file(filename, **kwargs):
@@ -10,7 +14,7 @@ def load_arm_file(filename, **kwargs):
     filename: str
        The name of the file to load.
 
-    Additional keyword arguments are passed into :py:func:`act.io.armfiles.read_netcdf`
+    Additional keyword arguments are passed into :py:func:`act.io.arm.read_arm_netcdf`
 
     Returns
     -------
@@ -18,4 +22,4 @@ def load_arm_file(filename, **kwargs):
         The xarray dataset containing the file data.
     """
 
-    return read_netcdf(filename, **kwargs)
+    return read_arm_netcdf(filename, **kwargs)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -203,7 +203,10 @@ def test_plot_regridded_CF_timeseries():
         atb_total_4D, atb_mol_4D, subcolum_num, time_num, z_full_km_3D, z_half_km_3D,
         Ncolumns, Npoints, Nlevels, Nglevels, col_num, newgrid_bot, newgrid_top)
     # Set input parameters.
-    cmap = 'act_HomeyerRainbow'
+    try:
+        cmap = 'HomeyerRainbow'
+    except:
+        cmap = 'act_HomeyerRainbow'
     field_to_plot = ["CF"]
     vmin_max = [(0., 1.)]
     log_plot = [False]
@@ -239,7 +242,10 @@ def test_plot_subcolumn_timeseries():
     my_e3sm = emc2.simulator.main.make_simulated_data(
         my_e3sm, KAZR, N_sub,do_classify=False, convert_zeros_to_nan=True,
         unstack_dims=True, finalize_fields=True,use_rad_logic=True)
-    cmap = 'act_HomeyerRainbow'
+    try:
+        cmap = 'HomeyerRainbow'
+    except:
+        cmap = 'act_HomeyerRainbow'
     field_to_plot = ["sub_col_beta_p_tot", "sub_col_Ze_att_tot"]
     vmin_max = [(1e-8, 1e-3),  (-50., 10.)]
     log_plot = [True,  False]


### PR DESCRIPTION
This fix enables EMC^2 to work with both post-v2.0.0 ACT and earlier versions.
Addresses issue #110 