### PR TITLE
Bug fixes in hydrometeor assignment

### DIFF
--- a/emc2/simulator/psd.py
+++ b/emc2/simulator/psd.py
@@ -106,24 +106,17 @@ def calc_mu_lambda(model, hyd_type="cl",
         N_name = model.N_field[hyd_type]
         if not is_conv:
             q_name = model.q_names_stratiform[hyd_type]
-            frac_name = model.strat_frac_names[hyd_type]
         else:
             q_name = model.q_names_convective[hyd_type]
-            frac_name = model.conv_frac_names[hyd_type]
     else:
         if not is_conv:
             N_name = "strat_n_subcolumns_%s" % hyd_type
             q_name = "strat_q_subcolumns_%s" % hyd_type
-            frac_name = model.strat_frac_names[hyd_type]
         else:
             N_name = "conv_n_subcolumns_%s" % hyd_type
             q_name = "conv_q_subcolumns_%s" % hyd_type
-            frac_name = model.conv_frac_names[hyd_type]
 
     
-    frac_array = np.tile(
-        model.ds[frac_name].values, (model.num_subcolumns, 1, 1))
-    frac_array = np.where(frac_array == 0, 1, frac_array)
     if model.Rho_hyd[hyd_type] == 'variable':    
         Rho_hyd = model.ds[model.variable_density[hyd_type]].values
     else:
@@ -136,7 +129,7 @@ def calc_mu_lambda(model, hyd_type="cl",
             if not subcolumns:
                 mus = 0.0005714 * (column_ds[N_name].values * 1e-6) + 0.2714  # converting to cm-3 per Martin, 1994
             else:
-                mus = 0.0005714 * (column_ds[N_name].values * frac_array * 1e-6) + 0.2714  # converting to cm-3
+                mus = 0.0005714 * (column_ds[N_name].values * 1e-6) + 0.2714  # converting to cm-3
             mus = 1 / mus**2 - 1
             mus = np.where(mus < dispersion_mu_bounds[0], dispersion_mu_bounds[0], mus)
             mus = np.where(mus > dispersion_mu_bounds[1], dispersion_mu_bounds[1], mus)
@@ -157,7 +150,7 @@ def calc_mu_lambda(model, hyd_type="cl",
         fit_lambda = ((c * column_ds[N_name].astype('float64') * 1e6 * gamma(column_ds["mu"] + d + 1.)) /
                       (column_ds[q_name].astype('float64') * gamma(column_ds["mu"] + 1.)))**(1 / d)
     else:
-        fit_lambda = ((c * column_ds[N_name].astype('float64') * frac_array *
+        fit_lambda = ((c * column_ds[N_name].astype('float64') *
                        1e6 * gamma(column_ds["mu"] + d + 1.)) /
                       (column_ds[q_name].astype('float64') * gamma(column_ds["mu"] + 1.))) ** (1 / d)
 

--- a/emc2/simulator/radar_moments.py
+++ b/emc2/simulator/radar_moments.py
@@ -443,8 +443,8 @@ def calc_radar_micro(instrument, model, z_values, atm_ext, OD_from_sfc=True,
 
     for hyd_type in hyd_types:
         print("Calculating moments for hydrometeor %s" % hyd_type)
-        frac_names = "strat_frac_subcolumns_%s" % hyd_type #++MZ bug fix model.strat_frac_names[hyd_type]
-        n_names = "strat_n_subcolumns_%s" % hyd_type #++MZ bug fix model.N_field[hyd_type]
+        frac_names = "strat_frac_subcolumns_%s" % hyd_type
+        n_names = "strat_n_subcolumns_%s" % hyd_type
         if not np.isin("sub_col_Ze_tot_strat", [x for x in model.ds.keys()]):
             model.ds["sub_col_Ze_tot_strat"] = xr.DataArray(
                 np.zeros(Dims), dims=model.ds.strat_q_subcolumns_cl.dims)
@@ -631,9 +631,9 @@ def calc_radar_micro(instrument, model, z_values, atm_ext, OD_from_sfc=True,
 
         vel_param_a = model.vel_param_a
         vel_param_b = model.vel_param_b
-        frac_names = "strat_frac_subcolumns_%s" % hyd_type #++MZ bug fix model.strat_frac_names[hyd_type]
-        n_names = "strat_n_subcolumns_%s" % hyd_type #++MZ bug fix model.N_field[hyd_type]
-        total_hydrometeor = model.ds[frac_names] * model.ds[n_names] #++MZ model.ds[model.N_field[hyd_type]]
+        frac_names = "strat_frac_subcolumns_%s" % hyd_type
+        n_names = "strat_n_subcolumns_%s" % hyd_type
+        total_hydrometeor = model.ds[frac_names] * model.ds[n_names]
 
         Vd_tot = model.ds["sub_col_Vd_tot_strat"].values
         if hyd_type == "cl":
@@ -896,7 +896,7 @@ def _calc_sigma_d_tot_cl(tt, N_0, lambdas, mu, instrument,
     num_diam = len(p_diam)
     Dims = Vd_tot.shape
     for k in range(Dims[2]):
-        if np.all(total_hydrometeor[0, tt, k] == 0): #++MZ total_hydrometeor[tt, k] == 0):
+        if np.all(total_hydrometeor[:, tt, k] == 0):
             continue
         N_0_tmp = N_0[:, tt, k].astype('float64')
         N_0_tmp, d_diam_tmp = np.meshgrid(N_0_tmp, p_diam)
@@ -927,7 +927,7 @@ def _calc_sigma_d_tot(tt, num_subcolumns, v_tmp, N_0, lambdas, mu,
     if tt % 50 == 0:
         print('Stratiform moment for class progress: %d/%d' % (tt, Dims[1]))
     for k in range(Dims[2]):
-        if np.all(total_hydrometeor[0, tt, k] == 0): #++MZ total_hydrometeor[tt, k] == 0):
+        if np.all(total_hydrometeor[:, tt, k] == 0):
             continue
         N_0_tmp = N_0[:, tt, k]
         lambda_tmp = lambdas[:, tt, k]
@@ -968,7 +968,7 @@ def _calculate_observables_liquid(tt, total_hydrometeor, N_0, lambdas, mu,
         print("Processing column %d/%d" % (tt, N_0.shape[1]))
     np.seterr(all="ignore")
     for k in range(height_dims):
-        if np.all(total_hydrometeor[0, tt, k] == 0): #++MZ total_hydrometeor[tt,k] == 0; original
+        if np.all(total_hydrometeor[:, tt, k] == 0):
             continue
         if num_subcolumns > 1:
             N_0_tmp = np.squeeze(N_0[:, tt, k])
@@ -1019,7 +1019,7 @@ def _calculate_other_observables(tt, total_hydrometeor, N_0, lambdas,
     moment_denom_tot = np.zeros_like(Ze)
     hyd_ext = np.zeros_like(Ze)
     for k in range(Dims[2]):
-        if np.all(total_hydrometeor[0, tt, k] == 0): #++MZ total_hydrometeor[tt,k] == 0; original
+        if np.all(total_hydrometeor[:, tt, k] == 0):
             continue
 
         num_diam = len(p_diam)

--- a/emc2/simulator/radar_moments.py
+++ b/emc2/simulator/radar_moments.py
@@ -443,8 +443,8 @@ def calc_radar_micro(instrument, model, z_values, atm_ext, OD_from_sfc=True,
 
     for hyd_type in hyd_types:
         print("Calculating moments for hydrometeor %s" % hyd_type)
-        frac_names = model.strat_frac_names[hyd_type]
-        n_names = model.N_field[hyd_type]
+        frac_names = "strat_frac_subcolumns_%s" % hyd_type #++MZ bug fix model.strat_frac_names[hyd_type]
+        n_names = "strat_n_subcolumns_%s" % hyd_type #++MZ bug fix model.N_field[hyd_type]
         if not np.isin("sub_col_Ze_tot_strat", [x for x in model.ds.keys()]):
             model.ds["sub_col_Ze_tot_strat"] = xr.DataArray(
                 np.zeros(Dims), dims=model.ds.strat_q_subcolumns_cl.dims)
@@ -631,9 +631,9 @@ def calc_radar_micro(instrument, model, z_values, atm_ext, OD_from_sfc=True,
 
         vel_param_a = model.vel_param_a
         vel_param_b = model.vel_param_b
-        frac_names = model.strat_frac_names[hyd_type]
-        n_names = model.N_field[hyd_type]
-        total_hydrometeor = model.ds[frac_names] * model.ds[model.N_field[hyd_type]]
+        frac_names = "strat_frac_subcolumns_%s" % hyd_type #++MZ bug fix model.strat_frac_names[hyd_type]
+        n_names = "strat_n_subcolumns_%s" % hyd_type #++MZ bug fix model.N_field[hyd_type]
+        total_hydrometeor = model.ds[frac_names] * model.ds[n_names] #++MZ model.ds[model.N_field[hyd_type]]
 
         Vd_tot = model.ds["sub_col_Vd_tot_strat"].values
         if hyd_type == "cl":
@@ -896,7 +896,7 @@ def _calc_sigma_d_tot_cl(tt, N_0, lambdas, mu, instrument,
     num_diam = len(p_diam)
     Dims = Vd_tot.shape
     for k in range(Dims[2]):
-        if np.all(total_hydrometeor[tt, k] == 0):
+        if np.all(total_hydrometeor[0, tt, k] == 0): #++MZ total_hydrometeor[tt, k] == 0):
             continue
         N_0_tmp = N_0[:, tt, k].astype('float64')
         N_0_tmp, d_diam_tmp = np.meshgrid(N_0_tmp, p_diam)
@@ -927,7 +927,7 @@ def _calc_sigma_d_tot(tt, num_subcolumns, v_tmp, N_0, lambdas, mu,
     if tt % 50 == 0:
         print('Stratiform moment for class progress: %d/%d' % (tt, Dims[1]))
     for k in range(Dims[2]):
-        if np.all(total_hydrometeor[tt, k] == 0):
+        if np.all(total_hydrometeor[0, tt, k] == 0): #++MZ total_hydrometeor[tt, k] == 0):
             continue
         N_0_tmp = N_0[:, tt, k]
         lambda_tmp = lambdas[:, tt, k]
@@ -968,7 +968,7 @@ def _calculate_observables_liquid(tt, total_hydrometeor, N_0, lambdas, mu,
         print("Processing column %d/%d" % (tt, N_0.shape[1]))
     np.seterr(all="ignore")
     for k in range(height_dims):
-        if np.all(total_hydrometeor[tt, k] == 0):
+        if np.all(total_hydrometeor[0, tt, k] == 0): #++MZ total_hydrometeor[tt,k] == 0; original
             continue
         if num_subcolumns > 1:
             N_0_tmp = np.squeeze(N_0[:, tt, k])
@@ -1019,7 +1019,7 @@ def _calculate_other_observables(tt, total_hydrometeor, N_0, lambdas,
     moment_denom_tot = np.zeros_like(Ze)
     hyd_ext = np.zeros_like(Ze)
     for k in range(Dims[2]):
-        if np.all(total_hydrometeor[tt, k] == 0):
+        if np.all(total_hydrometeor[0, tt, k] == 0): #++MZ total_hydrometeor[tt,k] == 0; original
             continue
 
         num_diam = len(p_diam)

--- a/emc2/simulator/subcolumn.py
+++ b/emc2/simulator/subcolumn.py
@@ -322,7 +322,7 @@ def set_precip_sub_col_frac(model, is_conv, N_columns=None, use_rad_logic=True,
         print(f"num_subcolumns == 1 (subcolumn generator turned off); setting subcolumns frac "
               f"fields to 1 for {precip_type} precip based on q > 0. kg/kg")
         for hyd_type in precip_types:
-            if is_conv:
+            if not is_conv: #++MZ bug fix adding not
                 q_use = np.tile(model.ds[model.q_names_stratiform[hyd_type]], (1, 1, 1))
             else:
                 q_use = np.tile(model.ds[model.q_names_convective[hyd_type]], (1, 1, 1))

--- a/emc2/simulator/subcolumn.py
+++ b/emc2/simulator/subcolumn.py
@@ -322,10 +322,10 @@ def set_precip_sub_col_frac(model, is_conv, N_columns=None, use_rad_logic=True,
         print(f"num_subcolumns == 1 (subcolumn generator turned off); setting subcolumns frac "
               f"fields to 1 for {precip_type} precip based on q > 0. kg/kg")
         for hyd_type in precip_types:
-            if not is_conv: #++MZ bug fix adding not
-                q_use = np.tile(model.ds[model.q_names_stratiform[hyd_type]], (1, 1, 1))
-            else:
+            if is_conv:
                 q_use = np.tile(model.ds[model.q_names_convective[hyd_type]], (1, 1, 1))
+            else:
+                q_use = np.tile(model.ds[model.q_names_stratiform[hyd_type]], (1, 1, 1))
             model.ds[precip_type + '_frac_subcolumns_%s' % hyd_type] = xr.DataArray(
                 np.where(q_use > 0, 1., 0.), dims=(subcolumn_dims[0], subcolumn_dims[1], subcolumn_dims[2]))
     else:


### PR DESCRIPTION
Three bugs are fixed in subcolumn distribution and inconsistent hydrometeor fraction assignment.
1. In function _set_precip_sub_col_frac (subcolumn.py)_ that computes the subcolumn distribution of precipitation hydrometeors, EMC2 incorrectly passes the model convective hydrometeor mass to stratiform precipitation hydrometeors.
2. In _calc_lidar_micro (lidar_moments.py)_ and _calc_radar_micro (radar_moments.py)_, the use of hydrometeor fraction is inconsistent. Based on Israel's comment, this should not have a significant impact, as it was corrected/overridden at some point in the code.
3. In function _calc_mu_lambda (psd.py)_, the hydrometeor fraction uses the value without being distributed in subcolumns but the hydrometeor number and mass use values after being distributed in subcolumns.